### PR TITLE
Oauth2 기본 설정 적용 및 학습

### DIFF
--- a/src/main/java/me/spring/authapp/IndexController.java
+++ b/src/main/java/me/spring/authapp/IndexController.java
@@ -1,0 +1,13 @@
+package me.spring.authapp;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class IndexController {
+
+    @GetMapping("/")
+    public String index(){
+        return "index";
+    }
+}

--- a/src/main/java/me/spring/authapp/LoginController.java
+++ b/src/main/java/me/spring/authapp/LoginController.java
@@ -1,0 +1,12 @@
+package me.spring.authapp;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LoginController {
+    @GetMapping("/login")
+    public String login(){
+        return "login Page";
+    }
+}

--- a/src/main/java/me/spring/authapp/OAuth2ClientConfig.java
+++ b/src/main/java/me/spring/authapp/OAuth2ClientConfig.java
@@ -1,0 +1,22 @@
+package me.spring.authapp;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+public class OAuth2ClientConfig {
+
+    @Bean
+    SecurityFilterChain oauth2SecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests((authorizeHttpRequests) ->
+                    authorizeHttpRequests
+                            .anyRequest().authenticated()
+            );
+        http.oauth2Login(Customizer.withDefaults());
+        return http.build();
+    }
+}


### PR DESCRIPTION
Spring Security?
- 결국엔 일련의 보안 필터체인을 제공하는 프레임워크.
- 필터체인 세부 구성은 SecurityFilterChain 빈을 등록하고 XxxConfigurer를 활용한다.
- 그리고 SecurityFilterChain 빈을 등록한 클래스에 @EnableWebSecurity 애노테이션을 등록함으로서 서버 실행후 SecurityFilterChain 구성에 활용할 수 있게 한다.

이번 PR에 구성한 필터체인

HttpSecurity
- HTTP 보안 구성
- HTTP 요청에 대한 인증/인가, 세션, CORS, CSRF 등의 보안 정책 설정을 수행하는데 활용된다.
- [공식 문서](https://docs.spring.io/spring-security/reference/servlet/architecture.html#_customizing_a_spring_security_filter)에 의하면 Security Filter Chain DSL이라고 부르기도 한다.

AuthorizeHttpRequestsConfigurer
- 요청별 인가 규칙을 설정하는 DSL이다.
- 특정 url 및 url 패턴을 지정하고 인증 및 허용되는 인가 범위를 지정함으로서 리소스의 접근 권한 범위를 제어한다.
- AuthorizationFilter에 적용된다.

OAuth2LoginConfigurer
- OAuth2 인증시 AccessToken 교환 및 사용자 정보 엔드포인트 요청 등을 설정하는 DSL이다.
- Default 설정을 적용할 경우, DefaultLoginPageGeneratingFilter에 의한 기본 로그인 페이지가 적용된다.
